### PR TITLE
lti設定手順確認用ノートブックにて、画像ファイルを予め展開するよう修正

### DIFF
--- a/notebooks/021-Moodleの外部ツール設定例（lti1.3&JupyterHub）.ipynb
+++ b/notebooks/021-Moodleの外部ツール設定例（lti1.3&JupyterHub）.ipynb
@@ -30,18 +30,16 @@
    "metadata": {},
    "source": [
     "### 基本設定\n",
-    "以下のセルを実行すると、設定例を示す画像を表示します（Markdownだと画像を元のサイズで表示できないため、IPython.displayのImageを使用しています）"
+    "\n",
+    "設定例を以下に表示します。"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41ab5e16",
+   "cell_type": "markdown",
+   "id": "a50bb908",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "from IPython.display import Image\n",
-    "Image(filename=\"images/021/moodle_lti13_jupyterhub_sample.png\")"
+    "![](images/021/moodle_lti13_jupyterhub_sample.png)"
    ]
   },
   {
@@ -73,19 +71,15 @@
    "source": [
     "### NRPS利用の場合の設定\n",
     "\n",
-    "NRPS(Names and Role Provisioning Services)を利用できる場合、基本設定を以下のように修正します。  \n",
-    "以下のセルを実行すると、設定例を示す画像を表示します（Markdownだと画像を元のサイズで表示できないため、IPython.displayのImageを使用しています）"
+    "NRPS(Names and Role Provisioning Services)を利用できる場合、基本設定を以下のように修正します。"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b323d8a7",
+   "cell_type": "markdown",
+   "id": "89f2c04d",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "from IPython.display import Image\n",
-    "Image(filename=\"images/021/moodle_lti13_jupyterhub_sample_nrps.png\")"
+    "![](images/021/moodle_lti13_jupyterhub_sample_nrps.png)"
    ]
   }
  ],


### PR DESCRIPTION
github等で確認する際に画像ファイルのプレビューが表示されていないと確認しづらいため。